### PR TITLE
Feature - DESTDIR variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GOARCH		:= $(shell echo $(PLATFORM) | cut -d "/" -f 2)
 SUFFIX		:= $(GOOS)-$(GOARCH)
 VERSION		?= $(shell git describe --always --tags --dirty)
 BUILD_FLAGS	:= -ldflags="-s -w -X github.com/nicklasfrahm/$(TARGET)/cmd.version=$(VERSION)"
+DESTDIR		:= /usr/local/bin
 
 # Adjust the binary name on Windows.
 ifeq ($(GOOS),windows)
@@ -29,16 +30,15 @@ vagrant-up:
 vagrant-down:
 	cd deploy/vagrant; vagrant destroy -f
 
-/usr/local/bin/$(TARGET): bin/$(TARGET)-$(SUFFIX)
-	@sudo cp $^ $@
-	@sudo chmod 755 $@
+$(DESTDIR)/$(TARGET): bin/$(TARGET)-$(SUFFIX)
+	sudo install -Dm 755 $^ $@
 
 .PHONY: install
-install: /usr/local/bin/$(TARGET)
+install: $(DESTDIR)/$(TARGET)
 
 .PHONY: uninstall
 uninstall:
-	@sudo rm -f /usr/local/bin/$(TARGET)
+	@sudo rm -f $(DESTDIR)/$(TARGET)
 
 .PHONY: docker
 docker:

--- a/pkg/engine/config.go
+++ b/pkg/engine/config.go
@@ -62,6 +62,7 @@ func (c *Config) Verify() error {
 		return errors.New("configuration empty")
 	}
 
+	// TODO: Also allow versions in the format of `v1.24.4+k3s1`.
 	channelValid := false
 	for _, channel := range Channels {
 		if channel == c.Version {


### PR DESCRIPTION
This solves #21.

I added the `sudo` to the Makefile again so that the `root` user is not required to have `go` installed.

I need to revisit this. Maybe I can move the logic for the `GOOS` and the `GOARCH` into the build step.